### PR TITLE
Upgrade to Laravel 13.7 / PHP 8.3 / PHPUnit 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+.phpunit.cache/
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # df-amqp
 AMQP (Advanced Message Queuing Protocol) based client for DreamFactory.
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,18 @@
     }
   ],
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
     "dreamfactory/df-pubsub": "~0.2",
-    "php-amqplib/php-amqplib": "^3.1.1"
+    "php-amqplib/php-amqplib": "^3.5"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/tests/AMQPClientTest.php
+++ b/tests/AMQPClientTest.php
@@ -15,14 +15,14 @@ class AMQPClientTest extends \DreamFactory\Core\Testing\TestCase
     private $pass = 'secret';
     private $vhost = '/';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->client = $this->getNewClient();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->client);
 


### PR DESCRIPTION
## Summary
- Upgrade dep matrix to PHP `^8.3`, Laravel `^13.7`, PHPUnit `^11.5.3`, orchestra/testbench `^11.0`
- Bump `php-amqplib/php-amqplib` floor to `^3.5` (latest 3.x — L13-compatible, pure-PHP wire-protocol library with no Illuminate deps)
- Add `laravel/helpers ^1.8` to production `require` to polyfill `array_get`, `array_except`, `camel_case`, `camelize` (used by `Resources/Sub.php` line 122 and `Resources/Pub.php` line 56)
- PHPUnit 11 hygiene: add `: void` return type declarations to `setUp()` and `tearDown()` in `tests/AMQPClientTest.php`
- Add `.gitignore` for `vendor/`, `composer.lock`, phpunit caches

## Source-change scope
**Composer-only + one test stub** — no application/runtime patches required.

The package's runtime surface contains:
- No `DispatchesJobs` trait usage
- No `dispatchNow()` calls (uses `dispatch()` helper which still exists in L13)
- No `Illuminate\Database\Connection`/`Grammar`/`Builder` extensions (pure AMQP wire-protocol)
- No `CorsService`, `getDoctrineDriver`, `Mandrill`/`SparkPost` transports, `getDates` overrides
- The `BaseSubscriber` parent class (in df-pubsub) uses `Illuminate\Bus\Queueable` + `Dispatchable` traits which are unchanged in L13.7

## Wave 3 invariants confirmed
- Invariant #5/#17: PHPUnit 11 lowercase `setUp`/`tearDown` need `: void` — applied to AMQPClientTest
- Invariant #23: `camelize` is a laravel/helpers polyfill — covered by adding `laravel/helpers ^1.8` to require
- Invariant #3: `DispatchesJobs` trait still in L13.7 — n/a (not used)
- Invariants #6-#10 (ConnectionInterface, Grammar, getDoctrineDriver): n/a (pure AMQP, no Illuminate DB extensions)

## Test plan
- [x] Stage 1 (isolated): `composer validate --strict` clean; `composer install` resolves; `php -l` clean across all 18 src files; class-existence smoke 18/18 + 4 helper polyfills (array_get, camel_case, array_except, camelize) all green under L13.7.0
- [x] Stage 2 (host shift-173254): full host `composer install --no-dev` succeeds with path-repo aliases for `df-core` (1.0.99), `df-system` (0.6.99), `df-database` (1.4.99), `df-sqldb` (1.4.99), `df-user` (0.17.99), `df-pubsub` (0.2.99), `df-amqp` (0.3.99); strip-list applied (`df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server` + their VCS repos); `MongoDB\Laravel\MongoDBServiceProvider` commented in `config/app.php`; `package:discover` registers `DreamFactory\Core\AMQP\ServiceProvider`; smoke 22/22 green
- [ ] Live RabbitMQ broker integration test (deferred — `tests/AMQPClientTest.php` extends `DreamFactory\Core\Testing\TestCase` which requires a host-app `bootstrap/app.php` and a running broker on `localhost:5672`)

## Notes for reviewers
- `php-amqplib v3.7.4` resolved during Stage 2; pure-PHP, no Illuminate dependency surface
- df-amqp's `BaseSubscriber` parent (df-pubsub) was upgraded to L13 in a prior wave on `shift/laravel-13`; this PR depends on that branch transitively
- The package owns `DreamFactory\Core\AMQP\Contracts\AMQPConnectionInterface` (its own interface, not Illuminate's `ConnectionInterface`) — no L13 4th-param signature change applies